### PR TITLE
Add UI support for creating and cancelling operations

### DIFF
--- a/src/ui/operations_view.py
+++ b/src/ui/operations_view.py
@@ -1,14 +1,198 @@
-"""Operations table placeholder."""
+"""Operations management view allowing basic CRUD."""
 from __future__ import annotations
 
-from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+from datetime import datetime
 
+from PySide6.QtWidgets import (
+    QComboBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..services.account_service import AccountService
 from ..services.operation_service import OperationService
 
 
 class OperationsView(QWidget):
+    """Simple view to create and cancel operations from the main UI."""
+
     def __init__(self) -> None:
         super().__init__()
         self.service = OperationService()
+        self.account_service = AccountService()
+        self.account_lookup: dict[int, str] = {}
+
         layout = QVBoxLayout(self)
-        layout.addWidget(QLabel("Gestione operaciones en la vista avanzada"))
+
+        self.message_label = QLabel()
+        self.message_label.setObjectName("operationsMessage")
+        self.message_label.setVisible(False)
+
+        form_group = QGroupBox("Nueva operación")
+        form_layout = QFormLayout()
+
+        self.origin_combo = QComboBox()
+        self.hedge_combo = QComboBox()
+        self.mode_combo = QComboBox()
+        self.mode_combo.addItems(["calificacion", "credito_no_retorno"])
+        self.source_combo = QComboBox()
+        self.source_combo.addItems(["efectivo", "credito"])
+
+        self.event_input = QLineEdit()
+        self.stake_input = QLineEdit("25")
+        self.odds_a_input = QLineEdit("2.0")
+        self.odds_b_input = QLineEdit("2.1")
+        self.comm_input = QLineEdit("5.0")
+
+        form_layout.addRow("Cuenta origen", self.origin_combo)
+        form_layout.addRow("Cuenta cobertura", self.hedge_combo)
+        form_layout.addRow("Evento", self.event_input)
+        form_layout.addRow("Modo", self.mode_combo)
+        form_layout.addRow("Origen stake", self.source_combo)
+        form_layout.addRow("Stake A", self.stake_input)
+        form_layout.addRow("Cuota A", self.odds_a_input)
+        form_layout.addRow("Cuota B", self.odds_b_input)
+        form_layout.addRow("Comisión B", self.comm_input)
+
+        form_group.setLayout(form_layout)
+
+        buttons_layout = QHBoxLayout()
+        self.create_button = QPushButton("Crear operación")
+        self.create_button.clicked.connect(self._create_operation)
+        buttons_layout.addWidget(self.create_button)
+        buttons_layout.addStretch(1)
+
+        self.table = QTableWidget(0, 8)
+        self.table.setHorizontalHeaderLabels(
+            [
+                "ID",
+                "Fecha",
+                "Evento",
+                "Cuenta origen",
+                "Cobertura",
+                "Stake A",
+                "Cobertura B",
+                "Estado",
+            ]
+        )
+        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.table.setSelectionMode(QTableWidget.SingleSelection)
+        self.table.setEditTriggers(QTableWidget.NoEditTriggers)
+
+        table_actions = QHBoxLayout()
+        self.delete_button = QPushButton("Eliminar seleccionada")
+        self.delete_button.clicked.connect(self._cancel_selected)
+        table_actions.addWidget(self.delete_button)
+        table_actions.addStretch(1)
+
+        layout.addWidget(form_group)
+        layout.addLayout(buttons_layout)
+        layout.addWidget(self.message_label)
+        layout.addWidget(self.table)
+        layout.addLayout(table_actions)
+        layout.addStretch(1)
+
+        self._load_accounts()
+        self._refresh_table()
+
+    def _load_accounts(self) -> None:
+        self.account_lookup.clear()
+        self.origin_combo.clear()
+        self.hedge_combo.clear()
+
+        accounts = self.account_service.list_accounts()
+        for account in accounts:
+            if account.id is None:
+                continue
+            self.account_lookup[account.id] = account.name
+            if account.type == "origen":
+                self.origin_combo.addItem(account.name, account.id)
+            elif account.type == "contraposicion":
+                self.hedge_combo.addItem(account.name, account.id)
+
+        if self.origin_combo.count() == 0:
+            self.origin_combo.addItem("No hay cuentas de origen", -1)
+        if self.hedge_combo.count() == 0:
+            self.hedge_combo.addItem("No hay cuentas de cobertura", -1)
+
+    def _create_operation(self) -> None:
+        self._set_message("")
+        origin_id = int(self.origin_combo.currentData() or -1)
+        hedge_id = int(self.hedge_combo.currentData() or -1)
+        if origin_id <= 0 or hedge_id <= 0:
+            self._set_message("Debe seleccionar cuentas válidas", error=True)
+            return
+
+        try:
+            operation = self.service.create_operation(
+                origin_account_id=origin_id,
+                hedge_account_id=hedge_id,
+                event=self.event_input.text() or "Evento",
+                mode=self.mode_combo.currentText(),
+                stake_source=self.source_combo.currentText(),
+                stake_a=float(self.stake_input.text()),
+                odds_a=float(self.odds_a_input.text()),
+                odds_b=float(self.odds_b_input.text()),
+                commission_b=float(self.comm_input.text()),
+            )
+        except Exception as exc:  # pragma: no cover - UI feedback
+            self._set_message(str(exc), error=True)
+            return
+
+        self._set_message(f"Operación {operation.id} creada correctamente")
+        self._refresh_table()
+
+    def _cancel_selected(self) -> None:
+        self._set_message("")
+        selected = self.table.currentRow()
+        if selected < 0:
+            self._set_message("Seleccione una operación", error=True)
+            return
+        operation_id_item = self.table.item(selected, 0)
+        if not operation_id_item:
+            self._set_message("No se pudo identificar la operación", error=True)
+            return
+        operation_id = int(operation_id_item.text())
+        try:
+            self.service.cancel_operation(operation_id, note="Cancelada desde UI")
+        except Exception as exc:  # pragma: no cover - UI feedback
+            self._set_message(str(exc), error=True)
+            return
+        self._set_message(f"Operación {operation_id} eliminada")
+        self._refresh_table()
+
+    def _refresh_table(self) -> None:
+        operations = [op for op in self.service.list_operations(include_cancelled=False)]
+        self.table.setRowCount(len(operations))
+        for row, operation in enumerate(operations):
+            self.table.setItem(row, 0, QTableWidgetItem(str(operation.id)))
+            self.table.setItem(row, 1, QTableWidgetItem(self._format_ts(operation.ts)))
+            self.table.setItem(row, 2, QTableWidgetItem(operation.event))
+            self.table.setItem(row, 3, QTableWidgetItem(self.account_lookup.get(operation.origin_account_id, "")))
+            self.table.setItem(row, 4, QTableWidgetItem(self.account_lookup.get(operation.hedge_account_id, "")))
+            self.table.setItem(row, 5, QTableWidgetItem(f"{operation.stake_a:.2f}"))
+            self.table.setItem(row, 6, QTableWidgetItem(f"{operation.hedge_stake_b:.2f}"))
+            self.table.setItem(row, 7, QTableWidgetItem(operation.status))
+        self.table.resizeColumnsToContents()
+
+    def _set_message(self, text: str, *, error: bool = False) -> None:
+        if text:
+            self.message_label.setText(text)
+            self.message_label.setStyleSheet("color: red;" if error else "color: green;")
+            self.message_label.setVisible(True)
+        else:
+            self.message_label.clear()
+            self.message_label.setVisible(False)
+
+    @staticmethod
+    def _format_ts(ts: datetime) -> str:
+        return ts.strftime("%Y-%m-%d %H:%M")

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.domain.models import Account
 from src.services.account_service import AccountService
 from src.services.operation_service import OperationService
@@ -37,3 +39,61 @@ def test_create_operation_locks_funds(tmp_path, monkeypatch):
     updated_hedge = account_service.list_accounts()[1]
     assert updated_origin.balance < 200.0
     assert updated_hedge.balance < 400.0
+
+
+def test_cancel_operation_releases_funds(tmp_path, monkeypatch):
+    account_service, op_service = setup_services(tmp_path, monkeypatch)
+    origin, hedge = account_service.list_accounts()
+    operation = op_service.create_operation(
+        origin_account_id=origin.id,
+        hedge_account_id=hedge.id,
+        event="Partido",
+        mode="calificacion",
+        stake_source="efectivo",
+        stake_a=25.0,
+        odds_a=2.0,
+        odds_b=2.1,
+        commission_b=5.0,
+    )
+
+    cancelled = op_service.cancel_operation(operation.id)
+
+    updated_origin = account_service.list_accounts()[0]
+    updated_hedge = account_service.list_accounts()[1]
+
+    assert cancelled.status == "CANCELADA"
+    assert updated_origin.balance == pytest.approx(200.0)
+    assert updated_hedge.balance == pytest.approx(400.0)
+
+
+def test_list_operations_excludes_cancelled(tmp_path, monkeypatch):
+    account_service, op_service = setup_services(tmp_path, monkeypatch)
+    origin, hedge = account_service.list_accounts()
+    first = op_service.create_operation(
+        origin_account_id=origin.id,
+        hedge_account_id=hedge.id,
+        event="Partido",
+        mode="calificacion",
+        stake_source="efectivo",
+        stake_a=25.0,
+        odds_a=2.0,
+        odds_b=2.1,
+        commission_b=5.0,
+    )
+    second = op_service.create_operation(
+        origin_account_id=origin.id,
+        hedge_account_id=hedge.id,
+        event="Otro",
+        mode="calificacion",
+        stake_source="efectivo",
+        stake_a=10.0,
+        odds_a=1.8,
+        odds_b=2.0,
+        commission_b=5.0,
+    )
+
+    op_service.cancel_operation(first.id)
+
+    remaining = op_service.list_operations(include_cancelled=False)
+    assert all(op.status != "CANCELADA" for op in remaining)
+    assert {op.id for op in remaining} == {second.id}


### PR DESCRIPTION
## Summary
- add listing and cancellation helpers to the operation service
- replace the operations view placeholder with a form and table to create and cancel bets
- extend the operations tests to cover cancellation and filtering behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5725528548328a5d3f4ce2b628d7e