### PR TITLE
feat: add account owner metadata and bonus management

### DIFF
--- a/src/data/db.py
+++ b/src/data/db.py
@@ -13,10 +13,12 @@ PRAGMA foreign_keys=ON;
 CREATE TABLE IF NOT EXISTS accounts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
+    owner TEXT NOT NULL,
     type TEXT CHECK(type IN ('origen','contraposicion')) NOT NULL,
     currency TEXT DEFAULT 'EUR',
     commission REAL DEFAULT 5.0,
     balance REAL NOT NULL DEFAULT 0.0,
+    bonus_balance REAL NOT NULL DEFAULT 0.0,
     notes TEXT,
     created_at DATETIME,
     updated_at DATETIME

--- a/src/domain/models.py
+++ b/src/domain/models.py
@@ -11,9 +11,11 @@ class Account:
     id: Optional[int]
     name: str
     type: str  # 'origen' or 'contraposicion'
+    owner: str
     currency: str = "EUR"
     commission: float = 5.0
     balance: float = 0.0
+    bonus_balance: float = 0.0
     notes: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/src/ui/accounts_view.py
+++ b/src/ui/accounts_view.py
@@ -1,22 +1,168 @@
-"""Accounts view showing balances."""
+"""Accounts view with management tools for balances and bonuses."""
 from __future__ import annotations
 
-from PySide6.QtWidgets import QLabel, QListWidget, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
 
+from ..domain.models import Account
 from ..services.account_service import AccountService
 
 
 class AccountsView(QWidget):
     def __init__(self) -> None:
         super().__init__()
-        layout = QVBoxLayout(self)
-        self.list_widget = QListWidget()
-        layout.addWidget(QLabel("Cuentas disponibles"))
-        layout.addWidget(self.list_widget)
         self.service = AccountService()
+        self.accounts: list[Account] = []
+
+        layout = QVBoxLayout(self)
+
+        layout.addWidget(QLabel("Cuentas disponibles"))
+        self.list_widget = QListWidget()
+        layout.addWidget(self.list_widget)
+
+        layout.addWidget(self._build_creation_group())
+        layout.addWidget(self._build_transaction_group())
+
         self.refresh()
 
+    def _build_creation_group(self) -> QGroupBox:
+        group = QGroupBox("Crear cuenta")
+        form = QFormLayout(group)
+
+        self.name_input = QLineEdit()
+        self.owner_input = QLineEdit()
+        self.type_combo = QComboBox()
+        self.type_combo.addItems(["origen", "contraposicion"])
+        self.currency_input = QLineEdit("EUR")
+
+        form.addRow("Nombre", self.name_input)
+        form.addRow("Persona", self.owner_input)
+        form.addRow("Tipo", self.type_combo)
+        form.addRow("Divisa", self.currency_input)
+
+        button = QPushButton("Crear cuenta")
+        button.clicked.connect(self._handle_create_account)
+        form.addRow(button)
+        return group
+
+    def _build_transaction_group(self) -> QGroupBox:
+        group = QGroupBox("Registrar movimiento")
+        form = QFormLayout(group)
+
+        self.account_combo = QComboBox()
+        self.account_combo.currentIndexChanged.connect(self._update_amount_prefix)
+        self.movement_combo = QComboBox()
+        self.movement_combo.addItem("Depósito", userData="deposit")
+        self.movement_combo.addItem("Bono recibido", userData="incentive")
+        self.movement_combo.addItem("Retirada", userData="withdrawal")
+
+        self.amount_input = QDoubleSpinBox()
+        self.amount_input.setRange(0.0, 1_000_000.0)
+        self.amount_input.setDecimals(2)
+        self.amount_input.setPrefix("€ ")
+
+        self.note_input = QLineEdit()
+
+        form.addRow("Cuenta", self.account_combo)
+        form.addRow("Movimiento", self.movement_combo)
+        form.addRow("Importe", self.amount_input)
+        form.addRow("Nota", self.note_input)
+
+        button = QPushButton("Registrar")
+        button.clicked.connect(self._handle_transaction)
+        form.addRow(button)
+        return group
+
     def refresh(self) -> None:
+        self.accounts = self.service.list_accounts()
         self.list_widget.clear()
-        for account in self.service.list_accounts():
-            self.list_widget.addItem(f"{account.name} — {account.balance:.2f} {account.currency}")
+        self.account_combo.blockSignals(True)
+        self.account_combo.clear()
+        for account in self.accounts:
+            display = (
+                f"{account.name} ({account.owner}) — "
+                f"Saldo: {account.balance:.2f} {account.currency} | "
+                f"Bono: {account.bonus_balance:.2f} {account.currency}"
+            )
+            self.list_widget.addItem(display)
+            self.account_combo.addItem(display, userData=account.id)
+        self.account_combo.blockSignals(False)
+        self._update_amount_prefix()
+
+    def _handle_create_account(self) -> None:
+        name = self.name_input.text().strip()
+        owner = self.owner_input.text().strip()
+        currency = self.currency_input.text().strip().upper() or "EUR"
+        if not name or not owner:
+            QMessageBox.warning(self, "Datos incompletos", "Nombre y persona son obligatorios.")
+            return
+
+        account = Account(
+            id=None,
+            name=name,
+            owner=owner,
+            type=self.type_combo.currentText(),
+            currency=currency,
+        )
+        try:
+            self.service.create_account(account)
+        except Exception as exc:  # pragma: no cover - UI feedback
+            QMessageBox.critical(self, "Error", str(exc))
+            return
+
+        self.name_input.clear()
+        self.owner_input.clear()
+        self.currency_input.setText(currency)
+        self.refresh()
+
+    def _handle_transaction(self) -> None:
+        if not self.accounts:
+            QMessageBox.information(self, "Sin cuentas", "Primero crea una cuenta.")
+            return
+
+        account_id = self.account_combo.currentData()
+        if account_id is None:
+            QMessageBox.warning(self, "Selección inválida", "Selecciona una cuenta válida.")
+            return
+
+        amount = self.amount_input.value()
+        if amount <= 0:
+            QMessageBox.warning(self, "Importe inválido", "Introduce un importe positivo.")
+            return
+
+        kind = self.movement_combo.currentData()
+        adjusted_amount = -amount if kind == "withdrawal" else amount
+        note = self.note_input.text().strip() or None
+
+        try:
+            self.service.apply_transaction(
+                account_id=account_id,
+                kind=kind,
+                amount=adjusted_amount,
+                note=note,
+            )
+        except Exception as exc:  # pragma: no cover - UI feedback
+            QMessageBox.critical(self, "Error", str(exc))
+            return
+
+        self.amount_input.setValue(0.0)
+        self.note_input.clear()
+        self.refresh()
+
+    def _update_amount_prefix(self) -> None:
+        if 0 <= self.account_combo.currentIndex() < len(self.accounts):
+            currency = self.accounts[self.account_combo.currentIndex()].currency
+            self.amount_input.setPrefix(f"{currency} ")
+        else:
+            self.amount_input.setPrefix("€ ")

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,5 +1,4 @@
 from src.domain.models import Account
-from src.domain.models import Account
 from src.services.account_service import AccountService
 
 
@@ -12,11 +11,15 @@ def test_create_account_and_transaction(tmp_path, monkeypatch):
     monkeypatch.setattr("src.data.db.get_db_path", fake_get_db_path)
     service = AccountService()
 
-    account = service.create_account(Account(id=None, name="Test", type="origen", balance=0.0))
+    account = service.create_account(
+        Account(id=None, name="Test", owner="Alice", type="origen", balance=0.0)
+    )
     assert account.id is not None
 
     service.apply_transaction(account_id=account.id, kind="deposit", amount=100.0)
+    service.apply_transaction(account_id=account.id, kind="incentive", amount=25.0)
     accounts = service.list_accounts()
     assert accounts[0].balance == 100.0
+    assert accounts[0].bonus_balance == 25.0
 
     assert service.reconcile_account(account.id)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -13,8 +13,19 @@ def setup_services(tmp_path, monkeypatch):
 
     monkeypatch.setattr("src.data.db.get_db_path", fake_get_db_path)
     account_service = AccountService()
-    origin = account_service.create_account(Account(id=None, name="Origen", type="origen", balance=0.0))
-    hedge = account_service.create_account(Account(id=None, name="Exchange", type="contraposicion", commission=5.0, balance=0.0))
+    origin = account_service.create_account(
+        Account(id=None, name="Origen", owner="Alice", type="origen", balance=0.0)
+    )
+    hedge = account_service.create_account(
+        Account(
+            id=None,
+            name="Exchange",
+            owner="Casa",
+            type="contraposicion",
+            commission=5.0,
+            balance=0.0,
+        )
+    )
     account_service.apply_transaction(account_id=origin.id, kind="deposit", amount=200.0)
     account_service.apply_transaction(account_id=hedge.id, kind="deposit", amount=400.0)
     return account_service, OperationService(account_service)

--- a/tests/test_settlements.py
+++ b/tests/test_settlements.py
@@ -13,8 +13,12 @@ def prepare_operation(tmp_path, monkeypatch):
 
     monkeypatch.setattr("src.data.db.get_db_path", fake_get_db_path)
     account_service = AccountService()
-    origin = account_service.create_account(Account(id=None, name="Origen", type="origen", balance=0.0))
-    hedge = account_service.create_account(Account(id=None, name="Exchange", type="contraposicion", balance=0.0))
+    origin = account_service.create_account(
+        Account(id=None, name="Origen", owner="Alice", type="origen", balance=0.0)
+    )
+    hedge = account_service.create_account(
+        Account(id=None, name="Exchange", owner="Casa", type="contraposicion", balance=0.0)
+    )
     account_service.apply_transaction(account_id=origin.id, kind="deposit", amount=200.0)
     account_service.apply_transaction(account_id=hedge.id, kind="deposit", amount=400.0)
     op_service = OperationService(account_service)


### PR DESCRIPTION
## Summary
- add owner and bonus balance fields to accounts and update account service logic to track incentives separately from cash
- expand the accounts view to create accounts per person and register deposits, bonuses, and withdrawals while showing cash and bonus balances
- adjust automated tests to cover the new account metadata and bonus tracking behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d79e6afc0883289485b403f465b576